### PR TITLE
Change hero image to use cdn link

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,7 +7,7 @@ const nextConfig = {
     dirs: ['src', 'e2e'],
   },
   images: {
-    domains: ['bit.ly'],
+    domains: ['bit.ly', 'res.cloudinary.com'],
   },
 };
 

--- a/src/components/HeroHeader/DesktopHero.tsx
+++ b/src/components/HeroHeader/DesktopHero.tsx
@@ -1,14 +1,13 @@
 import Image from 'next/image';
 import React from 'react';
 import Navbar from '../Navbar';
-import bgImage from '../../../public/images/hero-image.jpg';
 import LinkButton from '../LinkButton/LinkButton';
 
 export default function HeroHeader() {
   return (
     <div>
       <Image
-        src={bgImage}
+        src="https://res.cloudinary.com/reactjs-devs-ke/image/upload/v1678532588/website-images/hero-image_dqpm0k.jpg"
         alt=""
         objectFit="cover"
         layout="fill"


### PR DESCRIPTION
This PR fixes Issue #118 by making changes to the Hero Background image, for it to load from a CDN based url rather than locally. 
![Screenshot from 2023-03-11 15-45-36](https://user-images.githubusercontent.com/106302681/224485328-5a93875f-d37a-4ec2-9336-cc30e8d96d9f.png)

